### PR TITLE
messages: Update messages for consistency with latest practical-revau…

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+use std::{error, fmt};
+
+/// An error enum for revault_net functionality
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub enum Error {
+    /// Error when using messages API
+    Message(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Message(ref e) => write!(f, "Message Error: {}", e),
+        }
+    }
+}
+
+impl error::Error for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,5 @@
 #![forbid(unsafe_code)]
 
 pub mod message;
+
+pub mod error;


### PR DESCRIPTION
…lt version

This PR makes revault_net messages consistent with the new specification at [practical-revault #219985a8]( https://github.com/re-vault/practical-revault/commits/master#219985a8b83fe389f7425ab5a3e24c4023729df6), except for some modifications to improve the code quality of the implementation. These changes include:

- Modified spend_opinions and spend_validations to contain `id` fields with each opinion.
- Modified field names from `spend_tx` to either `signed_spend_tx` or `unsigned_spend_tx` for clarity when using this lib.

To fix: concrete types for the pubkey and encrypted signature fields of `EncryptedSignature`.