### PR TITLE
contrib: add a script to generate a testing coverage report

### DIFF
--- a/contrib/gen_coverage.sh
+++ b/contrib/gen_coverage.sh
@@ -1,0 +1,14 @@
+set -ex
+
+rustup update nightly
+
+if ! command -v grcov &>/dev/null; then
+    cargo install grcov
+fi
+
+cargo clean
+CARGO_INCREMENTAL=0 RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests" RUSTDOCFLAGS="$RUSTFLAGS" cargo +nightly test
+grcov ./target/debug/ --source-dir . -t html --branch --ignore-not-existing --llvm -o ./target/grcov/
+firefox target/grcov/index.html
+
+set +ex


### PR DESCRIPTION
The same i use in `revault_tx`, always useful to have a global view of which paths are tested :)