### PR TITLE
Remove KX implementation, adapt API for servers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-revault_tx = { git = "https://github.com/darosior/revault", branch = "refinement_boundchecks", features = ["use-serde"] }
+revault_tx = { git = "https://github.com/re-vault/revault", features = ["use-serde"] }
 snow = { version = "0.7.2", features = ["libsodium-resolver"]}
 
 [dev-dependencies]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -288,6 +288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74ff4ece4ff5498718a232e92d53273903609c739052f5edf2a1a42c59586348"
 dependencies = [
  "bitcoin",
+ "serde",
 ]
 
 [[package]]
@@ -392,7 +393,6 @@ dependencies = [
 name = "revault_net"
 version = "0.0.1"
 dependencies = [
- "bitcoin",
  "revault_tx",
  "serde",
  "snow",
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "revault_tx"
 version = "0.0.1"
-source = "git+https://github.com/re-vault/revault_tx#f4d801844ac5f12702ff0c43dce2200b0905a25d"
+source = "git+https://github.com/re-vault/revault#283f2d133dfdeb967ef5098bff11b3a6d5d11ae5"
 dependencies = [
  "base64",
  "bitcoinconsensus",

--- a/fuzz/fuzz_targets/encrypt_roundtrip.rs
+++ b/fuzz/fuzz_targets/encrypt_roundtrip.rs
@@ -20,29 +20,6 @@ const RESP_PUBKEY: NoisePubKey = NoisePubKey([
     108, 67, 194, 161, 42, 72, 15, 38, 109, 193, 45, 125,
 ]);
 
-fn kx_channels() -> (KXChannel, KXChannel) {
-    let (init_1, msg_1) = KXHandshakeActOne::initiator(&INIT_PRIVKEY).unwrap();
-    let resp_1 = KXHandshakeActOne::responder(&RESP_PRIVKEY, &INIT_PUBKEY, &msg_1).unwrap();
-
-    let (resp_2, msg_2) = KXHandshakeActTwo::responder(resp_1).unwrap();
-    let server_channel = KXChannel::from_handshake(resp_2).unwrap();
-
-    let init_2 = KXHandshakeActTwo::initiator(init_1, &msg_2).unwrap();
-    let client_channel = KXChannel::from_handshake(init_2).unwrap();
-
-    (server_channel, client_channel)
-}
-
-fn kx_roundtrip(client_channel: &mut KXChannel, server_channel: &mut KXChannel, data: &[u8]) {
-    let cypher = encrypt_message(client_channel, &data).unwrap();
-    let plaintext = decrypt_message(server_channel, &cypher).unwrap();
-    assert_eq!(&plaintext, data);
-
-    let cypher = encrypt_message(server_channel, &data).unwrap();
-    let plaintext = decrypt_message(client_channel, &cypher).unwrap();
-    assert_eq!(&plaintext, data);
-}
-
 fn kk_channels() -> (KKChannel, KKChannel) {
     let (init_1, msg_1) = KKHandshakeActOne::initiator(&INIT_PRIVKEY, &RESP_PUBKEY).unwrap();
     let resp_1 = KKHandshakeActOne::responder(&RESP_PRIVKEY, &INIT_PUBKEY, &msg_1).unwrap();
@@ -57,19 +34,17 @@ fn kk_channels() -> (KKChannel, KKChannel) {
 }
 
 fn kk_roundtrip(client_channel: &mut KKChannel, server_channel: &mut KKChannel, data: &[u8]) {
-    let cypher = encrypt_message(client_channel, &data).unwrap();
-    decrypt_message(server_channel, &cypher).unwrap();
+    let cypher = client_channel.encrypt_message(&data).unwrap();
+    server_channel.decrypt_message(&cypher).unwrap();
 
-    let cypher = encrypt_message(server_channel, &data).unwrap();
-    decrypt_message(client_channel, &cypher).unwrap();
+    let cypher = server_channel.encrypt_message(&data).unwrap();
+    client_channel.decrypt_message(&cypher).unwrap();
 }
 
 fuzz_target!(|data: &[u8]| {
-    let (mut kx_client, mut kx_server) = kx_channels();
     let (mut kk_client, mut kk_server) = kk_channels();
 
     if data.len() < NOISE_MESSAGE_MAX_SIZE {
-        kx_roundtrip(&mut kx_client, &mut kx_server, data);
         kk_roundtrip(&mut kk_client, &mut kk_server, data);
 
         // Don't unwrap: they are surely invalid. But be sure we don't crash while
@@ -77,10 +52,8 @@ fuzz_target!(|data: &[u8]| {
         #[allow(unused)]
         if data.len() > NOISE_MESSAGE_HEADER_SIZE {
             let data = NoiseEncryptedMessage(data.to_vec());
-            decrypt_message(&mut kx_client, &data);
-            decrypt_message(&mut kx_server, &data);
-            decrypt_message(&mut kk_client, &data);
-            decrypt_message(&mut kk_server, &data);
+            kk_client.decrypt_message(&data);
+            kk_server.decrypt_message(&data);
         }
     }
 });

--- a/fuzz/fuzz_targets/encrypt_roundtrip.rs
+++ b/fuzz/fuzz_targets/encrypt_roundtrip.rs
@@ -22,7 +22,7 @@ const RESP_PUBKEY: NoisePubKey = NoisePubKey([
 
 fn kk_channels() -> (KKChannel, KKChannel) {
     let (init_1, msg_1) = KKHandshakeActOne::initiator(&INIT_PRIVKEY, &RESP_PUBKEY).unwrap();
-    let resp_1 = KKHandshakeActOne::responder(&RESP_PRIVKEY, &INIT_PUBKEY, &msg_1).unwrap();
+    let resp_1 = KKHandshakeActOne::responder(&RESP_PRIVKEY, &[INIT_PUBKEY], &msg_1).unwrap();
 
     let (resp_2, msg_2) = KKHandshakeActTwo::responder(resp_1).unwrap();
     let server_channel = KKChannel::from_handshake(resp_2).unwrap();

--- a/fuzz/fuzz_targets/transport.rs
+++ b/fuzz/fuzz_targets/transport.rs
@@ -32,7 +32,7 @@ fn kk_client_server(data: &[u8]) {
         cli_channel.write(&msg_sent).expect("Sending test message");
     });
 
-    let mut serv_transport = KKTransport::accept(listener, RESP_PRIVKEY, INIT_PUBKEY).unwrap();
+    let mut serv_transport = KKTransport::accept(listener, RESP_PRIVKEY, &[INIT_PUBKEY]).unwrap();
     if let Ok(msg) = serv_transport.read() {
         assert_eq!(&msg, data);
     }

--- a/fuzz/fuzz_targets/transport.rs
+++ b/fuzz/fuzz_targets/transport.rs
@@ -21,23 +21,6 @@ const RESP_PUBKEY: NoisePubKey = NoisePubKey([
     108, 67, 194, 161, 42, 72, 15, 38, 109, 193, 45, 125,
 ]);
 
-fn kx_client_server(data: &[u8]) {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    let msg_sent = data.to_vec();
-
-    thread::spawn(move || {
-        let mut cli_channel =
-            KXTransport::connect(addr, INIT_PRIVKEY).expect("Client channel connecting");
-        cli_channel.write(&msg_sent).expect("Sending test message");
-    });
-
-    let mut serv_transport = KXTransport::accept(listener, RESP_PRIVKEY, INIT_PUBKEY).unwrap();
-    if let Ok(msg) = serv_transport.read() {
-        assert_eq!(&msg, data);
-    }
-}
-
 fn kk_client_server(data: &[u8]) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -56,6 +39,5 @@ fn kk_client_server(data: &[u8]) {
 }
 
 fuzz_target!(|data: &[u8]| {
-    kx_client_server(data);
     kk_client_server(data);
 });

--- a/fuzz/run.sh
+++ b/fuzz/run.sh
@@ -1,4 +1,4 @@
 cargo install --force cargo-fuzz
 for target in $(ls fuzz/fuzz_targets);do
-    cargo +nightly fuzz run "${target%.*}" -- -max_len=66000 -runs=10000
+    cargo +nightly fuzz run "${target%.*}" -- -max_len=66000 -runs=20000
 done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,5 @@ pub mod noise;
 
 pub mod transport;
 
-pub mod error;
+mod error;
+pub use error::Error;

--- a/src/message.rs
+++ b/src/message.rs
@@ -219,6 +219,14 @@ mod tests {
         serde_json::from_str(&serde_json::to_string(&psbt_base64).unwrap()).unwrap()
     }
 
+    macro_rules! roundtrip {
+        ($msg:ident) => {
+            let serialized_msg = serde_json::to_string(&$msg).unwrap();
+            let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
+            assert_eq!($msg, deserialized_msg);
+        };
+    }
+
     #[test]
     fn serde_watchtower_sig() {
         let pubkey: PublicKey = get_dummy_pubkey();
@@ -234,10 +242,7 @@ mod tests {
             txid,
             deposit_outpoint,
         };
-        let serialized_msg = serde_json::to_string(&msg).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-
-        assert_eq!(msg, deserialized_msg);
+        roundtrip!(msg);
     }
 
     #[test]
@@ -245,10 +250,7 @@ mod tests {
         let ack = true;
         let txid: Txid = get_dummy_txid();
         let msg = watchtower::SigAck { ack, txid };
-        let serialized_msg = serde_json::to_string(&msg).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-
-        assert_eq!(msg, deserialized_msg);
+        roundtrip!(msg);
     }
 
     #[test]
@@ -259,19 +261,13 @@ mod tests {
             )
             .unwrap(),
         };
-        let serialized_msg = serde_json::to_string(&msg).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-
-        assert_eq!(msg, deserialized_msg);
+        roundtrip!(msg);
 
         // Response
         let msg = watchtower::SpendTx {
             transaction: get_dummy_spend_tx().as_bitcoin_serialized().unwrap(),
         };
-        let serialized_msg = serde_json::to_string(&msg).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-
-        assert_eq!(msg, deserialized_msg);
+        roundtrip!(msg);
     }
 
     #[test]
@@ -286,9 +282,7 @@ mod tests {
             signature: sig.clone(),
             id,
         };
-        let serialized_msg = serde_json::to_string(&msg1).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-        assert_eq!(msg1, deserialized_msg);
+        roundtrip!(msg1);
 
         // Encrypted signature
         let encrypted_signature = server::EncryptedSignature {
@@ -300,19 +294,14 @@ mod tests {
             encrypted_signature,
             id,
         };
-        let serialized_msg = serde_json::to_string(&msg2).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-        assert_eq!(msg2, deserialized_msg);
+        roundtrip!(msg2);
     }
 
     #[test]
     fn serde_server_get_sigs() {
         let id = get_dummy_txid();
         let msg = server::GetSigs { id };
-        let serialized_msg = serde_json::to_string(&msg).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-
-        assert_eq!(msg, deserialized_msg);
+        roundtrip!(msg);
     }
 
     #[test]
@@ -323,9 +312,7 @@ mod tests {
 
         // Cleartext signatures
         let msg1 = server::Sigs { signatures };
-        let serialized_msg = serde_json::to_string(&msg1).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-        assert_eq!(msg1, deserialized_msg);
+        roundtrip!(msg1);
 
         // Encrypted signatures
         let encrypted_signature = server::EncryptedSignature {
@@ -340,45 +327,32 @@ mod tests {
         let msg2 = server::EmergencySigs {
             encrypted_signatures,
         };
-        let serialized_msg = serde_json::to_string(&msg2).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-        assert_eq!(msg2, deserialized_msg);
+        roundtrip!(msg2);
 
         // No signatures
         let signatures = HashMap::new();
         let msg3 = server::Sigs { signatures };
-        let serialized_msg = serde_json::to_string(&msg3).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-        assert_eq!(msg3, deserialized_msg);
+        roundtrip!(msg3);
     }
 
     #[test]
     fn serde_server_request_spend() {
         let unsigned_spend_tx: SpendTransaction = get_dummy_spend_tx();
         let msg = server::SetSpendTx::from_spend_tx(unsigned_spend_tx).unwrap();
-        let serialized_msg = serde_json::to_string(&msg).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-
-        assert_eq!(msg, deserialized_msg);
+        roundtrip!(msg);
     }
 
     #[test]
     fn serde_cosigner_sign() {
         let tx = get_dummy_spend_tx();
         let msg = cosigner::Sign { tx };
-        let serialized_msg = serde_json::to_string(&msg).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-
-        assert_eq!(msg, deserialized_msg);
+        roundtrip!(msg);
     }
 
     #[test]
     fn serder_cosigner_signature_message() {
         let tx = get_dummy_spend_tx();
         let msg = cosigner::SignatureMessage { tx };
-        let serialized_msg = serde_json::to_string(&msg).unwrap();
-        let deserialized_msg = serde_json::from_str(&serialized_msg).unwrap();
-
-        assert_eq!(msg, deserialized_msg);
+        roundtrip!(msg);
     }
 }

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -23,10 +23,6 @@ pub const LENGTH_PREFIX_SIZE: usize = 8;
 pub const NOISE_MESSAGE_HEADER_SIZE: usize = MAC_SIZE + LENGTH_PREFIX_SIZE;
 /// Maximum size of a message before being encrypted; limited by Noise Protocol Framework
 pub const NOISE_PLAINTEXT_MAX_SIZE: usize = NOISE_MESSAGE_MAX_SIZE - NOISE_MESSAGE_HEADER_SIZE;
-/// e (no authentication tag appended)
-pub const KX_MSG_1_SIZE: usize = KEY_SIZE + HANDSHAKE_MESSAGE.len();
-/// e, ee, se, s, es
-pub const KX_MSG_2_SIZE: usize = 2 * KEY_SIZE + 2 * MAC_SIZE;
 /// e, es, ss
 pub const KK_MSG_1_SIZE: usize = KEY_SIZE + HANDSHAKE_MESSAGE.len() + MAC_SIZE;
 /// e, ee, se
@@ -51,157 +47,6 @@ impl FromStr for NoisePubKey {
 /// A static Noise private key
 #[derive(Debug)]
 pub struct NoisePrivKey(pub [u8; KEY_SIZE]);
-
-/// First round of the KX handshake
-#[derive(Debug)]
-pub struct KXHandshakeActOne {
-    state: HandshakeState,
-}
-
-/// Message sent during the first round of the KX handshake (e with no tag)
-#[derive(Debug)]
-pub struct KXMessageActOne(pub(crate) [u8; KX_MSG_1_SIZE]);
-
-impl KXHandshakeActOne {
-    /// Start the first act of the handshake as an initiator (sharing e)
-    pub fn initiator(
-        my_privkey: &NoisePrivKey,
-    ) -> Result<(KXHandshakeActOne, KXMessageActOne), Error> {
-        // Build the initial initiator state
-        let builder = Builder::with_resolver(
-            "Noise_KX_25519_ChaChaPoly_SHA256"
-                .parse()
-                .expect("Valid params"),
-            Box::new(SodiumResolver::default()),
-        );
-        let mut state = builder
-            .local_private_key(&my_privkey.0)
-            .build_initiator()
-            .map_err(|e| Error::Noise(format!("Failed to build state for initiator: {:?}", e)))?;
-
-        // Write the first message. We make the buffer large enough to contain the tag, as Snow
-        // would error otherwise, even if it does not actually use it (no PSK, therefore no inner
-        // key, therefore no possible AD).
-        let mut buf_with_tag = [0u8; KX_MSG_1_SIZE + MAC_SIZE];
-        state
-            .write_message(HANDSHAKE_MESSAGE, &mut buf_with_tag)
-            .map_err(|e| {
-                Error::Noise(format!(
-                    "Failed to write first message for initiator: {:?}",
-                    e
-                ))
-            })?;
-
-        // Strip the (NULL) handshake, as Snow would otherwise check it in the next stage!
-        let mut msg = [0u8; KX_MSG_1_SIZE];
-        msg.copy_from_slice(&buf_with_tag[..KX_MSG_1_SIZE]);
-
-        Ok((KXHandshakeActOne { state }, KXMessageActOne(msg)))
-    }
-
-    /// Start the first act of the handshake as a responder (reading e and doing wizardry with it)
-    pub fn responder(
-        my_privkey: &NoisePrivKey,
-        their_pubkey: &NoisePubKey,
-        message: &KXMessageActOne,
-    ) -> Result<KXHandshakeActOne, Error> {
-        // Build the initial responder state
-        let builder = Builder::with_resolver(
-            "Noise_KX_25519_ChaChaPoly_SHA256"
-                .parse()
-                .expect("Valid params"),
-            Box::new(SodiumResolver::default()),
-        );
-        let mut state = builder
-            .local_private_key(&my_privkey.0)
-            .remote_public_key(&their_pubkey.0)
-            .build_responder()
-            .map_err(|e| Error::Noise(format!("Failed to build state for responder: {:?}", e)))?;
-
-        // Check handshake version message
-        let mut msg = [0u8; KX_MSG_1_SIZE];
-        state.read_message(&message.0, &mut msg).map_err(|e| {
-            Error::Noise(format!(
-                "Failed to read first message for responder: {:?}",
-                e
-            ))
-        })?;
-        if &msg[..HANDSHAKE_MESSAGE.len()] != HANDSHAKE_MESSAGE {
-            return Err(Error::Noise(format!(
-                "Wrong handshake message. Expected '{:x?}' got '{:x?}'.",
-                HANDSHAKE_MESSAGE,
-                &msg[..HANDSHAKE_MESSAGE.len()]
-            )));
-        }
-
-        Ok(KXHandshakeActOne { state })
-    }
-}
-
-/// Final round of the KX handshake
-#[derive(Debug)]
-pub struct KXHandshakeActTwo {
-    state: HandshakeState,
-}
-
-/// Message sent during the second round of the KX handshake (e, ee, se, s, es)
-#[derive(Debug)]
-pub struct KXMessageActTwo(pub(crate) [u8; KX_MSG_2_SIZE]);
-
-impl KXHandshakeActTwo {
-    /// Start the second act of the handshake as an initiator (read e, ee, se, s, es)
-    pub fn initiator(
-        mut handshake: KXHandshakeActOne,
-        message: &KXMessageActTwo,
-    ) -> Result<KXHandshakeActTwo, Error> {
-        let mut _m = [0u8; KX_MSG_2_SIZE];
-        handshake
-            .state
-            .read_message(&message.0, &mut _m)
-            .map_err(|e| {
-                Error::Noise(format!("Initiator failed to read second message: {:?}", e))
-            })?;
-
-        Ok(KXHandshakeActTwo {
-            state: handshake.state,
-        })
-    }
-
-    /// Start the second act of the handshake as a responder (write e, ee, se, s, es)
-    pub fn responder(
-        mut handshake: KXHandshakeActOne,
-    ) -> Result<(KXHandshakeActTwo, KXMessageActTwo), Error> {
-        let mut msg = [0u8; KX_MSG_2_SIZE];
-        handshake.state.write_message(&[], &mut msg).map_err(|e| {
-            Error::Noise(format!("Responder failed to write second message: {:?}", e))
-        })?;
-
-        Ok((
-            KXHandshakeActTwo {
-                state: handshake.state,
-            },
-            KXMessageActTwo(msg),
-        ))
-    }
-}
-
-/// A wrapper over Snow's transport state for a KX Noise communication channel.
-#[derive(Debug)]
-pub struct KXChannel {
-    transport_state: TransportState,
-}
-
-impl KXChannel {
-    /// Create a Noise transport channel out of a succesfull handshake
-    pub fn from_handshake(state: KXHandshakeActTwo) -> Result<KXChannel, Error> {
-        let transport_state = state
-            .state
-            .into_transport_mode()
-            .map_err(|e| Error::Noise(format!("Failed to enter transport mode: {:?}", e)))?;
-
-        Ok(KXChannel { transport_state })
-    }
-}
 
 /// First round of the KK handshake
 #[derive(Debug)]
@@ -334,6 +179,10 @@ impl KKHandshakeActTwo {
     }
 }
 
+/// A cyphertext encrypted with [encrypt_message]
+#[derive(Debug)]
+pub struct NoiseEncryptedMessage(pub Vec<u8>);
+
 /// A wrapper over Snow's transport state for a KK Noise communication channel.
 #[derive(Debug)]
 pub struct KKChannel {
@@ -350,79 +199,48 @@ impl KKChannel {
 
         Ok(KKChannel { transport_state })
     }
-}
 
-/// A wrapper over Snow's transport state for a Noise communication channel.
-/// Can be either KX or KK for Revault.
-pub trait NoiseChannel {
-    /// Get the inner transport state
-    fn transport_state(&mut self) -> &mut TransportState;
-}
+    /// Use the channel to encrypt any given message. Pre-fixes the message with
+    /// (big-endian) length field and pads the message with 0s before encryption.
+    /// On success, returns the ciphertext.
+    pub fn encrypt_message(&mut self, message: &[u8]) -> Result<NoiseEncryptedMessage, Error> {
+        if message.len() > NOISE_PLAINTEXT_MAX_SIZE {
+            return Err(Error::Noise("Message is too large to encrypt".to_string()));
+        }
+        let mut output = vec![0u8; NOISE_MESSAGE_HEADER_SIZE + message.len()];
 
-impl NoiseChannel for KXChannel {
-    fn transport_state(&mut self) -> &mut TransportState {
-        &mut self.transport_state
+        let mut prefixed_message = vec![0u8; LENGTH_PREFIX_SIZE + message.len()];
+        let message_len: usize = MAC_SIZE + message.len();
+        prefixed_message[..LENGTH_PREFIX_SIZE].copy_from_slice(&message_len.to_be_bytes());
+        prefixed_message[LENGTH_PREFIX_SIZE..].copy_from_slice(message);
+        self.transport_state
+            .write_message(&prefixed_message, &mut output)
+            .map_err(|e| Error::Noise(format!("Header encryption failed: {:?}", e)))?;
+
+        Ok(NoiseEncryptedMessage(output))
     }
-}
 
-impl NoiseChannel for KKChannel {
-    fn transport_state(&mut self) -> &mut TransportState {
-        &mut self.transport_state
+    /// Get plaintext bytes from a Noise-encrypted message
+    pub fn decrypt_message(&mut self, message: &NoiseEncryptedMessage) -> Result<Vec<u8>, Error> {
+        // TODO: could be in NoiseEncryptedMessage's constructor?
+        if message.0.len() > NOISE_MESSAGE_MAX_SIZE {
+            return Err(Error::Noise("Message is too large to decrypt".to_string()));
+        }
+        if message.0.len() < NOISE_MESSAGE_HEADER_SIZE {
+            return Err(Error::Noise("Message is too small to decrypt".to_string()));
+        }
+        let mut output = vec![0u8; message.0.len()];
+
+        self.transport_state
+            .read_message(&message.0, &mut output)
+            .map_err(|e| Error::Noise(format!("Failed to decrypt message: {:?}", e)))?;
+
+        // We read the length prefix and the MAC, but we don't care about any of both.
+        // TODO: bench this against truncating and reverse-then-pop-then-reverse
+        Ok(output
+            .drain(LENGTH_PREFIX_SIZE..output.len() - MAC_SIZE)
+            .collect())
     }
-}
-
-/// A cyphertext encrypted with [encrypt_message]
-#[derive(Debug)]
-pub struct NoiseEncryptedMessage(pub Vec<u8>);
-
-/// Use the channel to encrypt any given message. Pre-fixes the message with
-/// (big-endian) length field and pads the message with 0s before encryption.
-/// On success, returns the ciphertext.
-pub fn encrypt_message(
-    channel: &mut impl NoiseChannel,
-    message: &[u8],
-) -> Result<NoiseEncryptedMessage, Error> {
-    if message.len() > NOISE_PLAINTEXT_MAX_SIZE {
-        return Err(Error::Noise("Message is too large to encrypt".to_string()));
-    }
-    let mut output = vec![0u8; NOISE_MESSAGE_HEADER_SIZE + message.len()];
-
-    let mut prefixed_message = vec![0u8; LENGTH_PREFIX_SIZE + message.len()];
-    let message_len: usize = MAC_SIZE + message.len();
-    prefixed_message[..LENGTH_PREFIX_SIZE].copy_from_slice(&message_len.to_be_bytes());
-    prefixed_message[LENGTH_PREFIX_SIZE..].copy_from_slice(message);
-    channel
-        .transport_state()
-        .write_message(&prefixed_message, &mut output)
-        .map_err(|e| Error::Noise(format!("Header encryption failed: {:?}", e)))?;
-
-    Ok(NoiseEncryptedMessage(output))
-}
-
-/// Get plaintext bytes from a Noise-encrypted message
-pub fn decrypt_message(
-    channel: &mut impl NoiseChannel,
-    message: &NoiseEncryptedMessage,
-) -> Result<Vec<u8>, Error> {
-    // TODO: could be in NoiseEncryptedMessage's constructor?
-    if message.0.len() > NOISE_MESSAGE_MAX_SIZE {
-        return Err(Error::Noise("Message is too large to decrypt".to_string()));
-    }
-    if message.0.len() < NOISE_MESSAGE_HEADER_SIZE {
-        return Err(Error::Noise("Message is too small to decrypt".to_string()));
-    }
-    let mut output = vec![0u8; message.0.len()];
-
-    channel
-        .transport_state()
-        .read_message(&message.0, &mut output)
-        .map_err(|e| Error::Noise(format!("Failed to decrypt message: {:?}", e)))?;
-
-    // We read the length prefix and the MAC, but we don't care about any of both.
-    // TODO: bench this against truncating and reverse-then-pop-then-reverse
-    Ok(output
-        .drain(LENGTH_PREFIX_SIZE..output.len() - MAC_SIZE)
-        .collect())
 }
 
 #[cfg(test)]
@@ -430,11 +248,9 @@ pub mod tests {
     use crate::{
         error::Error,
         noise::{
-            decrypt_message, encrypt_message, KKChannel, KKHandshakeActOne, KKHandshakeActTwo,
-            KKMessageActOne, KKMessageActTwo, KXChannel, KXHandshakeActOne, KXHandshakeActTwo,
-            KXMessageActOne, KXMessageActTwo, NoiseEncryptedMessage, NoisePrivKey, NoisePubKey,
-            KK_MSG_1_SIZE, KK_MSG_2_SIZE, KX_MSG_1_SIZE, KX_MSG_2_SIZE, NOISE_MESSAGE_HEADER_SIZE,
-            NOISE_MESSAGE_MAX_SIZE, NOISE_PLAINTEXT_MAX_SIZE,
+            KKChannel, KKHandshakeActOne, KKHandshakeActTwo, KKMessageActOne, KKMessageActTwo,
+            NoiseEncryptedMessage, NoisePrivKey, NoisePubKey, KK_MSG_1_SIZE, KK_MSG_2_SIZE,
+            NOISE_MESSAGE_HEADER_SIZE, NOISE_MESSAGE_MAX_SIZE, NOISE_PLAINTEXT_MAX_SIZE,
         },
     };
     use snow::{params::NoiseParams, resolvers::SodiumResolver, Builder, Keypair};
@@ -467,45 +283,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_kx_handshake_encrypted_transport() {
-        let hs_choice = HandshakeChoice::Kx;
-        let noise_params = get_noise_params(&hs_choice).unwrap();
-
-        // key gen
-        let initiator_keypair = generate_keypair(noise_params.clone());
-        let initiator_privkey = NoisePrivKey(initiator_keypair.private[..].try_into().unwrap());
-        let initiator_pubkey = NoisePubKey(initiator_keypair.public[..].try_into().unwrap());
-
-        let responder_keypair = generate_keypair(noise_params);
-        let responder_privkey = NoisePrivKey(responder_keypair.private[..].try_into().unwrap());
-
-        // client
-        let (cli_act_1, msg_1) = KXHandshakeActOne::initiator(&initiator_privkey).unwrap();
-
-        // server
-        let serv_act_1 =
-            KXHandshakeActOne::responder(&responder_privkey, &initiator_pubkey, &msg_1).unwrap();
-        let (serv_act_2, msg_2) = KXHandshakeActTwo::responder(serv_act_1).unwrap();
-        let mut server_channel = KXChannel::from_handshake(serv_act_2).unwrap();
-
-        // client
-        let cli_act_2 = KXHandshakeActTwo::initiator(cli_act_1, &msg_2).unwrap();
-        let mut client_channel = KXChannel::from_handshake(cli_act_2).unwrap();
-
-        // client encrypts message for server
-        let msg = "Hello".as_bytes();
-        let encrypted_msg = encrypt_message(&mut client_channel, &msg).unwrap();
-        let decrypted_msg = decrypt_message(&mut server_channel, &encrypted_msg).unwrap();
-        assert_eq!(msg.to_vec(), decrypted_msg);
-
-        // server encrypts message for client
-        let msg = "Goodbye".as_bytes();
-        let encrypted_msg = encrypt_message(&mut server_channel, &msg).unwrap();
-        let decrypted_msg = decrypt_message(&mut client_channel, &encrypted_msg).unwrap();
-        assert_eq!(msg.to_vec(), decrypted_msg);
-    }
-
-    #[test]
     fn test_kk_handshake_encrypted_transport() {
         let hs_choice = HandshakeChoice::Kk;
         let noise_params = get_noise_params(&hs_choice).unwrap();
@@ -535,14 +312,14 @@ pub mod tests {
 
         // client encrypts message for server
         let msg = "Hello".as_bytes();
-        let encrypted_msg = encrypt_message(&mut client_channel, &msg).unwrap();
-        let decrypted_msg = decrypt_message(&mut server_channel, &encrypted_msg).unwrap();
+        let encrypted_msg = client_channel.encrypt_message(&msg).unwrap();
+        let decrypted_msg = server_channel.decrypt_message(&encrypted_msg).unwrap();
         assert_eq!(msg.to_vec(), decrypted_msg);
 
         // server encrypts message for client
         let msg = "Goodbye".as_bytes();
-        let encrypted_msg = encrypt_message(&mut server_channel, &msg).unwrap();
-        let decrypted_msg = decrypt_message(&mut client_channel, &encrypted_msg).unwrap();
+        let encrypted_msg = server_channel.encrypt_message(&msg).unwrap();
+        let decrypted_msg = client_channel.decrypt_message(&encrypted_msg).unwrap();
         assert_eq!(msg.to_vec(), decrypted_msg);
     }
 
@@ -558,30 +335,39 @@ pub mod tests {
 
         let responder_keypair = generate_keypair(noise_params);
         let responder_privkey = NoisePrivKey(responder_keypair.private[..].try_into().unwrap());
+        let responder_pubkey = NoisePubKey(responder_keypair.public[..].try_into().unwrap());
 
         // client
-        let (_cli_act_1, msg_1) = KXHandshakeActOne::initiator(&initiator_privkey).unwrap();
+        let (_, msg_1) =
+            KKHandshakeActOne::initiator(&initiator_privkey, &responder_pubkey).unwrap();
 
         // server
         let serv_act_1 =
-            KXHandshakeActOne::responder(&responder_privkey, &initiator_pubkey, &msg_1).unwrap();
-        let (serv_act_2, _msg_2) = KXHandshakeActTwo::responder(serv_act_1).unwrap();
-        let mut server_channel = KXChannel::from_handshake(serv_act_2).unwrap();
+            KKHandshakeActOne::responder(&responder_privkey, &initiator_pubkey, &msg_1).unwrap();
+        let (serv_act_2, _msg_2) = KKHandshakeActTwo::responder(serv_act_1).unwrap();
+        let mut server_channel = KKChannel::from_handshake(serv_act_2).unwrap();
 
         // Hit the limit
         let msg = [0u8; NOISE_PLAINTEXT_MAX_SIZE];
-        encrypt_message(&mut server_channel, &msg).expect("Maximum allowed");
+        server_channel
+            .encrypt_message(&msg)
+            .expect("Maximum allowed");
 
         // Fail if msg too large
         let msg = [0u8; NOISE_MESSAGE_MAX_SIZE - NOISE_MESSAGE_HEADER_SIZE + 1];
-        encrypt_message(&mut server_channel, &msg).expect_err("Limit exceeded");
+        server_channel
+            .encrypt_message(&msg)
+            .expect_err("Limit exceeded");
 
         // We can encrypt an empty message
         let msg = b"";
-        encrypt_message(&mut server_channel, msg).expect("Empty message is fine to encrypt");
+        server_channel
+            .encrypt_message(msg)
+            .expect("Empty message is fine to encrypt");
 
         // We cannot decrypt an empty message
-        decrypt_message(&mut server_channel, &NoiseEncryptedMessage(msg.to_vec()))
+        server_channel
+            .decrypt_message(&NoiseEncryptedMessage(msg.to_vec()))
             .expect_err("Encrypted message with no header");
     }
 
@@ -610,19 +396,6 @@ pub mod tests {
 
         let bad_msg = KKMessageActTwo([1u8; KK_MSG_2_SIZE]);
         KKHandshakeActTwo::initiator(cli_act_1, &bad_msg).expect_err("So is this one.");
-
-        // KX handshake fails on client side if handshake is invalid.
-        let (cli_act_1, _) = KXHandshakeActOne::initiator(&initiator_privkey).unwrap();
-
-        let bad_msg = KXMessageActOne([std::u8::MAX; KX_MSG_1_SIZE]);
-        KXHandshakeActOne::responder(&responder_privkey, &initiator_pubkey, &bad_msg)
-            .expect_err("Invalid handshake in act one");
-
-        let bad_msg = KXMessageActTwo([std::u8::MAX; KX_MSG_2_SIZE]);
-        KXHandshakeActTwo::initiator(cli_act_1, &bad_msg).expect_err("Bad handshake state");
-
-        let (cli_act_1, _) = KXHandshakeActOne::initiator(&initiator_privkey).unwrap();
-        KXHandshakeActTwo::responder(cli_act_1).expect_err("Bad handshake state");
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -7,130 +7,13 @@
 use crate::{
     error::Error,
     noise::{
-        decrypt_message, encrypt_message, KKChannel, KKHandshakeActOne, KKHandshakeActTwo,
-        KKMessageActOne, KKMessageActTwo, KXChannel, KXHandshakeActOne, KXHandshakeActTwo,
-        KXMessageActOne, KXMessageActTwo, NoiseEncryptedMessage, NoisePrivKey, NoisePubKey,
-        KK_MSG_1_SIZE, KK_MSG_2_SIZE, KX_MSG_1_SIZE, KX_MSG_2_SIZE, NOISE_MESSAGE_MAX_SIZE,
+        KKChannel, KKHandshakeActOne, KKHandshakeActTwo, KKMessageActOne, KKMessageActTwo,
+        NoiseEncryptedMessage, NoisePrivKey, NoisePubKey, KK_MSG_1_SIZE, KK_MSG_2_SIZE,
+        NOISE_MESSAGE_MAX_SIZE,
     },
 };
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};
-
-/// Wrapper type for a TcpStream and KXChannel that automatically enforces authenticated and
-/// encrypted channels when communicating
-#[derive(Debug)]
-pub struct KXTransport {
-    stream: TcpStream,
-    channel: KXChannel,
-}
-
-impl KXTransport {
-    /// Perform an outgoing connection to the given address, and enact Noise KX handshake
-    /// with the given private key.
-    pub fn connect<A: ToSocketAddrs>(
-        addr: A,
-        my_noise_privkey: NoisePrivKey,
-    ) -> Result<KXTransport, Error> {
-        let mut stream = TcpStream::connect(addr)
-            .map_err(|e| Error::Transport(format!("TCP connection failed: {:?}", e)))?;
-
-        let (cli_act_1, msg_1) = KXHandshakeActOne::initiator(&my_noise_privkey)
-            .map_err(|e| Error::Noise(format!("Failed to initiate act 1: {:?}", e)))?;
-
-        // write msg_1 to stream (e)
-        stream.write_all(&msg_1.0).map_err(|e| {
-            Error::Transport(format!("Failed to write message 1 to TcpStream: {:?}", e))
-        })?;
-
-        // read msg_2 from stream (e, ee, se, s, es)
-        let mut msg_2 = [0u8; KX_MSG_2_SIZE];
-        stream.read_exact(&mut msg_2).map_err(|e| {
-            Error::Transport(format!("Failed to read message 2 from TcpStream: {:?}", e))
-        })?;
-
-        let msg_act_2 = KXMessageActTwo(msg_2);
-        let cli_act_2 = KXHandshakeActTwo::initiator(cli_act_1, &msg_act_2)
-            .map_err(|e| Error::Noise(format!("Failed to initiate act 2: {:?}", e)))?;
-        let channel = KXChannel::from_handshake(cli_act_2)
-            .map_err(|e| Error::Noise(format!("Failed to construct KXChannel: {:?}", e)))?;
-
-        Ok(KXTransport { stream, channel })
-    }
-
-    /// Accept an incoming connection and immediately perform the noise KX handshake
-    /// as a responder with the given keys.
-    pub fn accept(
-        listener: TcpListener,
-        my_noise_privkey: NoisePrivKey,
-        their_noise_pubkey: NoisePubKey,
-    ) -> Result<KXTransport, Error> {
-        let (mut stream, _) = listener
-            .accept()
-            .map_err(|e| Error::Transport(format!("TCP accept failed: {:?}", e)))?;
-
-        // read msg_1 from stream
-        let mut msg_1 = [0u8; KX_MSG_1_SIZE];
-        stream.read_exact(&mut msg_1).map_err(|e| {
-            Error::Transport(format!("Failed to read message 1 from TcpStream: {:?}", e))
-        })?;
-        let msg_act_1 = KXMessageActOne(msg_1);
-
-        let serv_act_1 =
-            KXHandshakeActOne::responder(&my_noise_privkey, &their_noise_pubkey, &msg_act_1)
-                .map_err(|e| Error::Noise(format!("Failed to respond in act 1: {:?}", e)))?;
-        let (serv_act_2, msg_2) = KXHandshakeActTwo::responder(serv_act_1)
-            .map_err(|e| Error::Noise(format!("Failed to respond in act 2: {:?}", e)))?;
-        let channel = KXChannel::from_handshake(serv_act_2)
-            .map_err(|e| Error::Noise(format!("Failed to construct KXChannel: {:?}", e)))?;
-
-        // write msg_2 to stream
-        stream.write_all(&msg_2.0).map_err(|e| {
-            Error::Transport(format!("Failed to write message 2 to TcpStream: {:?}", e))
-        })?;
-
-        Ok(KXTransport { stream, channel })
-    }
-
-    /// Write a message to the other end of the encrypted communication channel.
-    pub fn write(&mut self, msg: &[u8]) -> Result<(), Error> {
-        let encrypted_msg = encrypt_message(&mut self.channel, msg)?.0;
-        self.stream.write_all(&encrypted_msg).map_err(|e| {
-            Error::Transport(format!(
-                "Failed to send encrypted message with TcpStream: {:?}",
-                e
-            ))
-        })
-    }
-
-    /// Read a message from the other end of the encrypted communication channel.
-    pub fn read(&mut self) -> Result<Vec<u8>, Error> {
-        let mut encrypted_msg = vec![0u8; NOISE_MESSAGE_MAX_SIZE];
-        let mut bytes_read = 0;
-
-        // Note that read_to_end() will read thousands of bytes for whatever reason
-        // so we emulate it here.
-        loop {
-            match self.stream.read(&mut encrypted_msg) {
-                Ok(0) => break,
-                Ok(n) => bytes_read += n,
-                Err(e) => match e.kind() {
-                    // Fine, we may have gotten the message anyways. They just aren't polite
-                    io::ErrorKind::WouldBlock
-                    | io::ErrorKind::Interrupted
-                    | io::ErrorKind::ConnectionReset
-                    | io::ErrorKind::ConnectionAborted
-                    | io::ErrorKind::BrokenPipe => break,
-                    // That's actually bad
-                    _ => return Err(Error::Transport(format!("Reading from stream: '{}'", e))),
-                },
-            };
-        }
-        encrypted_msg.truncate(bytes_read);
-
-        let encrypted_msg = NoiseEncryptedMessage(encrypted_msg);
-        decrypt_message(&mut self.channel, &encrypted_msg)
-    }
-}
 
 /// Wrapper type for a TcpStream and KKChannel that automatically enforces authenticated and
 /// encrypted channels when communicating
@@ -210,7 +93,7 @@ impl KKTransport {
 
     /// Write a message to the other end of the encrypted communication channel.
     pub fn write(&mut self, msg: &[u8]) -> Result<(), Error> {
-        let encrypted_msg = encrypt_message(&mut self.channel, msg)?.0;
+        let encrypted_msg = self.channel.encrypt_message(msg)?.0;
         self.stream.write_all(&encrypted_msg).map_err(|e| {
             Error::Transport(format!(
                 "Failed to send encrypted message with TcpStream: {:?}",
@@ -245,7 +128,7 @@ impl KKTransport {
         encrypted_msg.truncate(bytes_read);
 
         let encrypted_msg = NoiseEncryptedMessage(encrypted_msg);
-        decrypt_message(&mut self.channel, &encrypted_msg)
+        self.channel.decrypt_message(&encrypted_msg)
     }
 }
 
@@ -253,84 +136,25 @@ impl KKTransport {
 mod tests {
     use super::*;
     use crate::error::Error;
-    use snow::{params::NoiseParams, resolvers::SodiumResolver, Builder, Keypair};
+    use snow::{resolvers::SodiumResolver, Builder, Keypair};
     use std::convert::TryInto;
     use std::thread;
 
-    #[derive(Debug, Clone)]
-    pub enum HandshakeChoice {
-        Kx,
-        Kk,
-    }
-
-    pub fn get_noise_params(hs_choice: &HandshakeChoice) -> Result<NoiseParams, Error> {
-        let noise_params: NoiseParams = match hs_choice {
-            HandshakeChoice::Kk => "Noise_KK_25519_ChaChaPoly_SHA256"
-                .parse()
-                .map_err(|e| Error::Noise(format!("Invalid Noise Pattern: {}", e)))?,
-            HandshakeChoice::Kx => "Noise_KX_25519_ChaChaPoly_SHA256"
-                .parse()
-                .map_err(|e| Error::Noise(format!("Invalid Noise Pattern: {}", e)))?,
-        };
-        Ok(noise_params)
-    }
-
     /// Revault must specify the SodiumResolver to use sodiumoxide as the cryptography provider
     /// when generating a static key pair for secure communication.
-    pub fn generate_keypair(noise_params: NoiseParams) -> Keypair {
+    pub fn generate_keypair() -> Keypair {
+        let noise_params = "Noise_KK_25519_ChaChaPoly_SHA256"
+            .parse()
+            .map_err(|e| Error::Noise(format!("Invalid Noise Pattern: {}", e)))
+            .unwrap();
         Builder::with_resolver(noise_params, Box::new(SodiumResolver::default()))
             .generate_keypair()
             .unwrap()
     }
 
     #[test]
-    fn test_transport_kx() {
-        // client init
-        let cli_handshake_choice = HandshakeChoice::Kx;
-        let cli_noise_params = get_noise_params(&cli_handshake_choice).unwrap();
-        let client_keypair = generate_keypair(cli_noise_params.clone());
-
-        // server init
-        let serv_handshake_choice = HandshakeChoice::Kx;
-        let serv_noise_params = get_noise_params(&serv_handshake_choice).unwrap();
-        let server_keypair = generate_keypair(serv_noise_params.clone());
-
-        let serv_privkey = NoisePrivKey(server_keypair.private[..].try_into().unwrap());
-        let client_pubkey = NoisePubKey(client_keypair.public[..].try_into().unwrap());
-
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        // client thread
-        let cli_thread = thread::spawn(move || {
-            let my_noise_privkey = NoisePrivKey(client_keypair.private[..].try_into().unwrap());
-
-            let mut cli_channel =
-                KXTransport::connect(addr, my_noise_privkey).expect("Client channel connecting");
-            let msg = "Test message".as_bytes();
-            cli_channel.write(&msg).expect("Sending test message");
-            msg
-        });
-
-        let mut server_transport = KXTransport::accept(listener, serv_privkey, client_pubkey)
-            .expect("Server channel binding and accepting");
-
-        let sent_msg = cli_thread.join().unwrap();
-        let received_msg = server_transport.read().unwrap();
-        assert_eq!(sent_msg.to_vec(), received_msg);
-    }
-
-    #[test]
     fn test_transport_kk() {
-        // client init part 1
-        let cli_handshake_choice = HandshakeChoice::Kk;
-        let cli_noise_params = get_noise_params(&cli_handshake_choice).unwrap();
-        let client_keypair = generate_keypair(cli_noise_params.clone());
-
-        //server init
-        let serv_handshake_choice = HandshakeChoice::Kk;
-        let serv_noise_params = get_noise_params(&serv_handshake_choice).unwrap();
-        let server_keypair = generate_keypair(serv_noise_params.clone());
+        let (client_keypair, server_keypair) = (generate_keypair(), generate_keypair());
 
         let client_pubkey = NoisePubKey(client_keypair.public[..].try_into().unwrap());
         let server_pubkey = NoisePubKey(server_keypair.public[..].try_into().unwrap());


### PR DESCRIPTION
Based on #21  and a fixup branch i had and made part of this PR.

This fixes our (embarassing) oversight that servers could somehow identify their servee out of the void..
We still need to discuss it, but i see no other way around.