### PR TITLE
NoisePrivkey to NoisePubkey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,8 @@ serde = { version = "1.0", features = ["derive"] }
 revault_tx = { git = "https://github.com/re-vault/revault_tx", features = ["use-serde"] }
 snow = { version = "0.7.2", features = ["libsodium-resolver"]}
 
+# Used for Noise crypto and generating pubkeys
+sodiumoxide = "0.2"
+
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,4 @@ mod error;
 pub use error::Error;
 
 pub use revault_tx::bitcoin;
+pub use sodiumoxide;


### PR DESCRIPTION
How comes we didn't add this since the begining ? The pubkey derivation in the tests was quite convoluted..