### PR TITLE
Communication Hardening

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,48 @@
 
 use std::{error, fmt};
 
+#[derive(Debug)]
+pub enum NoiseError {
+    /// Error from Snow's internals
+    Snow(snow::error::Error),
+    /// An invalid plaintext was passed for encryption
+    InvalidPlaintext,
+    /// An invalid ciphertext was passed for decryption
+    InvalidCiphertext,
+    /// Handshake message was invalid
+    BadHandshake,
+    /// Remote static public key mismatch from passed keys
+    MissingStaticKey,
+}
+
+impl From<snow::error::Error> for NoiseError {
+    fn from(error: snow::error::Error) -> Self {
+        Self::Snow(error)
+    }
+}
+
+impl fmt::Display for NoiseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Snow(ref e) => write!(f, "Snow Error: {}", e),
+            Self::InvalidPlaintext => write!(f, "Invalid plaintext. Message too large?"),
+            Self::InvalidCiphertext => write!(f, "Invalid ciphertext. Message too large?"),
+            Self::BadHandshake => write!(f, "Invalid handshake magic bytes"),
+            Self::MissingStaticKey => write!(
+                f,
+                "Missing sender's static public key to respond to handshake"
+            ),
+        }
+    }
+}
+
+impl error::Error for NoiseError {}
+
 /// An error enum for revault_net functionality
 #[derive(Debug)]
 pub enum Error {
     /// Error while using noise API
-    Noise(snow::error::Error),
+    Noise(NoiseError),
     /// Transport error
     Transport(std::io::Error),
 }
@@ -22,26 +59,14 @@ impl fmt::Display for Error {
 
 impl error::Error for Error {}
 
-impl From<snow::error::Error> for Error {
-    fn from(error: snow::error::Error) -> Self {
-        Error::Noise(error)
-    }
-}
-
-impl From<snow::error::PatternProblem> for Error {
-    fn from(error: snow::error::PatternProblem) -> Self {
-        Error::Noise(snow::error::Error::Pattern(error))
-    }
-}
-
-impl From<snow::error::Prerequisite> for Error {
-    fn from(error: snow::error::Prerequisite) -> Self {
-        Error::Noise(snow::error::Error::Prereq(error))
-    }
-}
-
 impl From<std::io::Error> for Error {
     fn from(error: std::io::Error) -> Self {
-        Error::Transport(error)
+        Self::Transport(error)
+    }
+}
+
+impl From<NoiseError> for Error {
+    fn from(error: NoiseError) -> Self {
+        Self::Noise(error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,8 +9,6 @@ pub enum Error {
     Noise(snow::error::Error),
     /// Transport error
     Transport(std::io::Error),
-    /// FIXME: remove this generic error variant
-    Other(String),
 }
 
 impl fmt::Display for Error {
@@ -18,7 +16,6 @@ impl fmt::Display for Error {
         match *self {
             Error::Noise(ref e) => write!(f, "Noise Error: {}", e),
             Error::Transport(ref e) => write!(f, "Transport Error: {}", e),
-            Error::Other(ref e) => write!(f, "Other Error: {}", e),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,24 +3,48 @@
 use std::{error, fmt};
 
 /// An error enum for revault_net functionality
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Debug)]
 pub enum Error {
-    /// Error when using messages API
-    Message(String),
-    /// Error while using snow API
-    Noise(String),
+    /// Error while using noise API
+    Noise(snow::error::Error),
     /// Transport error
-    Transport(String),
+    Transport(std::io::Error),
+    /// FIXME: remove this generic error variant
+    Other(String),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Message(ref e) => write!(f, "Message Error: {}", e),
             Error::Noise(ref e) => write!(f, "Noise Error: {}", e),
             Error::Transport(ref e) => write!(f, "Transport Error: {}", e),
+            Error::Other(ref e) => write!(f, "Other Error: {}", e),
         }
     }
 }
 
 impl error::Error for Error {}
+
+impl From<snow::error::Error> for Error {
+    fn from(error: snow::error::Error) -> Self {
+        Error::Noise(error)
+    }
+}
+
+impl From<snow::error::PatternProblem> for Error {
+    fn from(error: snow::error::PatternProblem) -> Self {
+        Error::Noise(snow::error::Error::Pattern(error))
+    }
+}
+
+impl From<snow::error::Prerequisite> for Error {
+    fn from(error: snow::error::Prerequisite) -> Self {
+        Error::Noise(snow::error::Error::Prereq(error))
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Error::Transport(error)
+    }
+}

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -5,7 +5,7 @@
 //!
 
 use crate::error::Error;
-use revault_tx::bitcoin::hashes::hex::FromHex;
+use revault_tx::bitcoin::hashes::hex::{Error as HexError, FromHex};
 
 use std::{convert::TryInto, str::FromStr};
 
@@ -39,12 +39,10 @@ pub const HANDSHAKE_MESSAGE: &[u8] = b"practical_revault_0";
 pub struct NoisePubKey(pub [u8; KEY_SIZE]);
 
 impl FromStr for NoisePubKey {
-    type Err = Error;
+    type Err = HexError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(
-            FromHex::from_hex(s).map_err(|e| Error::Other(e.to_string()))?,
-        ))
+        Ok(Self(FromHex::from_hex(s)?))
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -75,12 +75,28 @@ impl KKTransport {
         Ok(KKTransport { stream, channel })
     }
 
-    /// Write a message to the other end of the encrypted communication channel.
+    /// Write a message to the other end of the encrypted communication channel. Attempts
+    /// to recover from certain kinds of error.
     pub fn write(&mut self, msg: &[u8]) -> Result<(), Error> {
         let encrypted_msg = self.channel.encrypt_message(msg)?.0;
-        self.stream
-            .write_all(&encrypted_msg)
-            .map_err(|e| Error::Transport(e))
+        let mut attempts = 0;
+        loop {
+            match self.stream.write_all(&encrypted_msg) {
+                Ok(n) => return Ok(n),
+                // write_all returns the first error of non-ErrorKind::Interrupted kind that
+                // write returns, in which case no bytes were written to the writer, and can
+                // try again. Here we try up to 5 times.
+                Err(e) => {
+                    attempts += 1;
+                    if attempts == 5 {
+                        return Err(Error::from(e));
+                    } else {
+                        thread::sleep(Duration::from_secs(1));
+                        continue;
+                    }
+                }
+            }
+        }
     }
 
     /// Read a message from the other end of the encrypted communication channel.
@@ -98,13 +114,8 @@ impl KKTransport {
             .decrypt_message(&NoiseEncryptedMessage(cypherbody))
     }
 
-    /// Get the static public key of the peer
-    pub fn remote_static(&self) -> NoisePubKey {
-        self.channel.remote_static()
-    }
-
     /// Read a message from the other end of the encrypted communication channel.
-    /// Will recover from certain types of errors, those for which no bytes are
+    /// Will recover from certain kinds of error, those for which no bytes are
     /// read from the stream, by retrying up to 10 times with a 1s sleep between
     /// attempts. After 10 attempts, or an unrecoverable error, will return an
     /// error.  
@@ -128,6 +139,11 @@ impl KKTransport {
             };
             attempts += 1;
         }
+    }
+
+    /// Get the static public key of the peer
+    pub fn remote_static(&self) -> NoisePubKey {
+        self.channel.remote_static()
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -117,8 +117,8 @@ impl KKTransport {
 
     /// Read a message from the other end of the encrypted communication channel.
     /// Will recover from certain kinds of error, those for which no bytes are
-    /// read from the stream, by retrying up to 10 times with a 1s sleep between
-    /// attempts. After 10 attempts, or an unrecoverable error, will return an
+    /// read from the stream, by retrying up to 5 times with a 1s sleep between
+    /// attempts. After 5 attempts, or an unrecoverable error, will return an
     /// error.  
     pub fn read(&mut self) -> Result<Vec<u8>, Error> {
         let mut attempts = 0;
@@ -126,7 +126,7 @@ impl KKTransport {
             match self._read() {
                 Ok(msg) => return Ok(msg),
                 Err(error) => match error {
-                    e if attempts == 5 => return Err(e),
+                    e if attempts == 4 => return Err(e),
                     Error::Transport(e) => match e.kind() {
                         ErrorKind::UnexpectedEof => return Err(Error::Transport(e)),
                         ErrorKind::Interrupted => return Err(Error::Transport(e)),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -112,6 +112,7 @@ impl KKTransport {
         self.stream.read_exact(&mut cypherbody)?;
         self.channel
             .decrypt_message(&NoiseEncryptedMessage(cypherbody))
+            .map_err(|e| e.into())
     }
 
     /// Read a message from the other end of the encrypted communication channel.


### PR DESCRIPTION
Some of the functions used in transport could cause a caller to block indefinitely (e.g. if trying to connect to a server while it is down). For this reason a timeout is added to the `connect` method of `KKTransport`. In addition, the `read` and `write` methods now have some resilience to a subset of possible errors. If one of these errors is encountered, the thread will sleep for a second before retrying (up to 10 times) before returning an error.

Fixes #27
Fixes #28 