### PR TITLE
Use sodiumoxide PublicKey and SecretKey

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,26 +1,52 @@
 //! Revault_net error module
 
+// use std::io::Error as ErrorIO;
 use std::{error, fmt};
 
 /// An error enum for revault_net functionality
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Debug)]
 pub enum Error {
-    /// Error when using messages API
-    Message(String),
-    /// Error while using snow API
-    Noise(String),
+    /// Error while using noise API
+    Noise(snow::error::Error),
     /// Transport error
-    Transport(String),
+    Transport(std::io::Error),
+    /// FIXME: remove this generic error variant
+    Other(String),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Message(ref e) => write!(f, "Message Error: {}", e),
             Error::Noise(ref e) => write!(f, "Noise Error: {}", e),
+            Error::Snow(ref e) => write!(f, "Snow Error: {}", e),
             Error::Transport(ref e) => write!(f, "Transport Error: {}", e),
+            Error::Other(ref e) => write!(f, "Other Error: {}", e),
         }
     }
 }
 
 impl error::Error for Error {}
+
+impl From<snow::error::Error> for Error {
+    fn from(error: snow::error::Error) -> Self {
+        Error::Noise(error)
+    }
+}
+
+impl From<snow::error::PatternProblem> for Error {
+    fn from(error: snow::error::PatternProblem) -> Self {
+        Error::Noise(snow::error::Error::Pattern(error))
+    }
+}
+
+impl From<snow::error::Prerequisite> for Error {
+    fn from(error: snow::error::Prerequisite) -> Self {
+        Error::Noise(snow::error::Error::Prereq(error))
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Error::Transport(error)
+    }
+}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -12,9 +12,9 @@ use crate::{
         KK_MSG_2_SIZE, NOISE_MESSAGE_HEADER_SIZE,
     },
 };
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::time::Duration;
+use std::{thread, time::Duration};
 
 /// Wrapper type for a TcpStream and KKChannel that automatically enforces authenticated and
 /// encrypted channels when communicating
@@ -61,7 +61,6 @@ impl KKTransport {
 
         // read msg_1 from stream
         let mut msg_1 = [0u8; KK_MSG_1_SIZE];
-        // FIXME: timeout?
         stream.read_exact(&mut msg_1)?;
         let msg_act_1 = KKMessageActOne(msg_1);
 
@@ -85,8 +84,7 @@ impl KKTransport {
     }
 
     /// Read a message from the other end of the encrypted communication channel.
-    /// Will return on connection interruption. Note that this blocks (without timeout!)
-    pub fn read(&mut self) -> Result<Vec<u8>, Error> {
+    fn _read(&mut self) -> Result<Vec<u8>, Error> {
         let mut cypherheader = [0u8; NOISE_MESSAGE_HEADER_SIZE];
         self.stream.read_exact(&mut cypherheader)?;
         let msg_len = self
@@ -103,6 +101,33 @@ impl KKTransport {
     /// Get the static public key of the peer
     pub fn remote_static(&self) -> NoisePubKey {
         self.channel.remote_static()
+    }
+
+    /// Read a message from the other end of the encrypted communication channel.
+    /// Will recover from certain types of errors, those for which no bytes are
+    /// read from the stream, by retrying up to 10 times with a 1s sleep between
+    /// attempts. After 10 attempts, or an unrecoverable error, will return an
+    /// error.  
+    pub fn read(&mut self) -> Result<Vec<u8>, Error> {
+        let mut attempts = 0;
+        loop {
+            match self._read() {
+                Ok(msg) => return Ok(msg),
+                Err(error) => match error {
+                    e if attempts == 5 => return Err(e),
+                    Error::Transport(e) => match e.kind() {
+                        ErrorKind::UnexpectedEof => return Err(Error::Transport(e)),
+                        ErrorKind::Interrupted => return Err(Error::Transport(e)),
+                        _ => {
+                            thread::sleep(Duration::from_secs(1));
+                            continue;
+                        }
+                    },
+                    e => e,
+                },
+            };
+            attempts += 1;
+        }
     }
 }
 
@@ -153,5 +178,39 @@ mod tests {
         let sent_msg = cli_thread.join().unwrap();
         let received_msg = server_transport.read().unwrap();
         assert_eq!(sent_msg.to_vec(), received_msg);
+    }
+
+    #[test]
+    fn test_read_with_retry() {
+        let (client_keypair, server_keypair) = (generate_keypair(), generate_keypair());
+
+        let client_pubkey = NoisePubKey(client_keypair.public[..].try_into().unwrap());
+        let server_pubkey = NoisePubKey(server_keypair.public[..].try_into().unwrap());
+        let server_privkey = NoisePrivKey(server_keypair.private[..].try_into().unwrap());
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // client thread
+        let cli_thread = thread::spawn(move || {
+            let my_noise_privkey = NoisePrivKey(client_keypair.private[..].try_into().unwrap());
+            let their_noise_pubkey = server_pubkey;
+
+            let mut cli_channel =
+                KKTransport::connect(addr, &my_noise_privkey, &their_noise_pubkey)
+                    .expect("Client channel connecting");
+            let received_msg = cli_channel.read();
+            received_msg
+        });
+
+        let mut server_transport =
+            KKTransport::accept(&listener, &server_privkey, &[client_pubkey])
+                .expect("Server channel binding and accepting");
+        thread::sleep(Duration::from_secs(5)); // Simulate server down for 5 seconds
+        let msg = "Test message".as_bytes();
+        server_transport.write(&msg).expect("Sending test message");
+
+        let received_msg = cli_thread.join().unwrap();
+        assert_eq!(msg.to_vec(), received_msg.unwrap());
     }
 }


### PR DESCRIPTION
There's no need to re-implement `PublicKey` and `SecretKey` structs within revault_net. Instead use `PublicKey` and `SecretKey` from [sodiumoxide](https://docs.rs/sodiumoxide/0.2.6/sodiumoxide/crypto/box_/curve25519xsalsa20poly1305/index.html) which already have conversion functions and memory zeroing for `SecretKey` when it is dropped.

Fixes #29 

based on #33 