### PR TITLE
Use Sodiumoxide Keys

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -399,6 +399,7 @@ version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
  "revault_net",
+ "sodiumoxide",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.3"
+sodiumoxide = { version = "0.2", features = ["serde"] }
 
 [dependencies.revault_net]
 path = ".."

--- a/fuzz/fuzz_targets/encrypt_roundtrip.rs
+++ b/fuzz/fuzz_targets/encrypt_roundtrip.rs
@@ -3,20 +3,20 @@ use libfuzzer_sys::fuzz_target;
 use revault_net::noise::*;
 use std::convert::TryInto;
 
-const INIT_PRIVKEY: NoisePrivKey = NoisePrivKey([
+const INIT_PRIVKEY: SecretKey = SecretKey([
     16, 85, 69, 127, 155, 247, 36, 200, 184, 156, 230, 255, 16, 125, 113, 4, 95, 78, 76, 188, 58,
     21, 55, 146, 195, 160, 199, 82, 41, 109, 199, 81,
 ]);
-const INIT_PUBKEY: NoisePubKey = NoisePubKey([
+const INIT_PUBKEY: PublicKey = PublicKey([
     10, 12, 215, 103, 252, 231, 156, 109, 147, 53, 1, 147, 42, 240, 233, 242, 164, 67, 0, 81, 86,
     180, 233, 168, 75, 29, 216, 242, 15, 186, 225, 102,
 ]);
 
-const RESP_PRIVKEY: NoisePrivKey = NoisePrivKey([
+const RESP_PRIVKEY: SecretKey = SecretKey([
     96, 240, 118, 161, 68, 25, 19, 15, 12, 238, 118, 69, 95, 52, 3, 130, 2, 107, 15, 25, 135, 234,
     72, 36, 67, 124, 36, 228, 203, 101, 122, 110,
 ]);
-const RESP_PUBKEY: NoisePubKey = NoisePubKey([
+const RESP_PUBKEY: PublicKey = PublicKey([
     19, 103, 106, 15, 169, 190, 254, 15, 187, 105, 61, 163, 152, 251, 238, 139, 253, 160, 165, 89,
     108, 67, 194, 161, 42, 72, 15, 38, 109, 193, 45, 125,
 ]);
@@ -43,7 +43,7 @@ fn kk_roundtrip(client_channel: &mut KKChannel, server_channel: &mut KKChannel, 
     let length = server_channel.decrypt_header(&header).unwrap();
     assert_eq!(body.0.len(), length as usize);
     let plaintext = server_channel.decrypt_message(&body).unwrap();
-    assert_eq!(&plaintext, data);
+    assert_eq!(plaintext, data);
 
     // Server --> Client
     let cypher = server_channel.encrypt_message(data).unwrap();
@@ -53,7 +53,7 @@ fn kk_roundtrip(client_channel: &mut KKChannel, server_channel: &mut KKChannel, 
     let length = client_channel.decrypt_header(&header).unwrap();
     assert_eq!(body.0.len(), length as usize);
     let plaintext = client_channel.decrypt_message(&body).unwrap();
-    assert_eq!(&plaintext, data);
+    assert_eq!(plaintext, data);
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/transport.rs
+++ b/fuzz/fuzz_targets/transport.rs
@@ -1,22 +1,23 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use revault_net::{noise::*, transport::*};
+use revault_net::noise::{PublicKey, SecretKey};
+use revault_net::transport::*;
 use std::{net::TcpListener, thread};
 
-const INIT_PRIVKEY: NoisePrivKey = NoisePrivKey([
+const INIT_PRIVKEY: SecretKey = SecretKey([
     16, 85, 69, 127, 155, 247, 36, 200, 184, 156, 230, 255, 16, 125, 113, 4, 95, 78, 76, 188, 58,
     21, 55, 146, 195, 160, 199, 82, 41, 109, 199, 81,
 ]);
-const INIT_PUBKEY: NoisePubKey = NoisePubKey([
+const INIT_PUBKEY: PublicKey = PublicKey([
     10, 12, 215, 103, 252, 231, 156, 109, 147, 53, 1, 147, 42, 240, 233, 242, 164, 67, 0, 81, 86,
     180, 233, 168, 75, 29, 216, 242, 15, 186, 225, 102,
 ]);
 
-const RESP_PRIVKEY: NoisePrivKey = NoisePrivKey([
+const RESP_PRIVKEY: SecretKey = SecretKey([
     96, 240, 118, 161, 68, 25, 19, 15, 12, 238, 118, 69, 95, 52, 3, 130, 2, 107, 15, 25, 135, 234,
     72, 36, 67, 124, 36, 228, 203, 101, 122, 110,
 ]);
-const RESP_PUBKEY: NoisePubKey = NoisePubKey([
+const RESP_PUBKEY: PublicKey = PublicKey([
     19, 103, 106, 15, 169, 190, 254, 15, 187, 105, 61, 163, 152, 251, 238, 139, 253, 160, 165, 89,
     108, 67, 194, 161, 42, 72, 15, 38, 109, 193, 45, 125,
 ]);
@@ -34,7 +35,7 @@ fn kk_client_server(data: &[u8]) {
 
     let mut serv_transport = KKTransport::accept(&listener, &RESP_PRIVKEY, &[INIT_PUBKEY]).unwrap();
     if let Ok(msg) = serv_transport.read() {
-        assert_eq!(&msg, data);
+        assert_eq!(msg, data);
     }
 }
 

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -5,12 +5,15 @@
 //!
 
 use crate::error::NoiseError;
-use revault_tx::bitcoin::hashes::hex::{Error as HexError, FromHex};
 
-use std::{convert::TryInto, str::FromStr};
+use std::convert::TryInto;
 
 use snow::{resolvers::SodiumResolver, Builder, HandshakeState, TransportState};
-use sodiumoxide::crypto::scalarmult::curve25519;
+
+/// The static public key used to enact Noise authenticated and encrypted channels
+pub use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::PublicKey;
+/// The static secret key used to enact Noise authenticated and encrypted channels
+pub use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::SecretKey;
 
 /// The size of a key, either public or private, on the Curve25519
 pub const KEY_SIZE: usize = 32;
@@ -32,32 +35,6 @@ pub const KK_MSG_2_SIZE: usize = KEY_SIZE + MAC_SIZE;
 /// Sent for versioning and identification during handshake
 pub const HANDSHAKE_MESSAGE: &[u8] = b"practical_revault_0";
 
-// A Curve25519 public key, abstracted out as a "Noise pubkey" for callers
-// who don't need to know about the crypto parameters.
-/// A static Noise public key
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct NoisePubKey(pub [u8; KEY_SIZE]);
-
-impl FromStr for NoisePubKey {
-    type Err = HexError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(FromHex::from_hex(s)?))
-    }
-}
-
-/// A static Noise private key
-#[derive(Debug)]
-pub struct NoisePrivKey(pub [u8; KEY_SIZE]);
-
-impl NoisePrivKey {
-    /// Compute the corresponding public key.
-    pub fn pubkey(&self) -> NoisePubKey {
-        let scalar = curve25519::Scalar(self.0);
-        NoisePubKey(curve25519::scalarmult_base(&scalar).0)
-    }
-}
-
 /// First round of the KK handshake
 #[derive(Debug)]
 pub struct KKHandshakeActOne {
@@ -70,8 +47,8 @@ pub struct KKMessageActOne(pub(crate) [u8; KK_MSG_1_SIZE]);
 impl KKHandshakeActOne {
     /// Start the first act of the handshake as an initiator (sharing e, es, ss)
     pub fn initiator(
-        my_privkey: &NoisePrivKey,
-        their_pubkey: &NoisePubKey,
+        my_privkey: &SecretKey,
+        their_pubkey: &PublicKey,
     ) -> Result<(KKHandshakeActOne, KKMessageActOne), NoiseError> {
         // Build the initial initiator state
         let builder = Builder::with_resolver(
@@ -94,8 +71,8 @@ impl KKHandshakeActOne {
 
     /// Start the first act of the handshake as a responder (reading e, es, ss and doing wizardry with it)
     pub fn responder(
-        my_privkey: &NoisePrivKey,
-        their_possible_pubkeys: &[NoisePubKey],
+        my_privkey: &SecretKey,
+        their_possible_pubkeys: &[PublicKey],
         message: &KKMessageActOne,
     ) -> Result<KKHandshakeActOne, NoiseError> {
         // TODO: estimate how inefficient it is.
@@ -255,8 +232,8 @@ impl KKChannel {
     }
 
     /// Get the static public key of the peer
-    pub fn remote_static(&self) -> NoisePubKey {
-        NoisePubKey(
+    pub fn remote_static(&self) -> PublicKey {
+        PublicKey(
             self.transport_state
                 .get_remote_static()
                 .expect(
@@ -273,28 +250,16 @@ impl KKChannel {
 pub mod tests {
     use crate::noise::{
         KKChannel, KKHandshakeActOne, KKHandshakeActTwo, KKMessageActOne, KKMessageActTwo,
-        NoiseEncryptedHeader, NoiseEncryptedMessage, NoisePrivKey, NoisePubKey, KEY_SIZE,
-        KK_MSG_1_SIZE, KK_MSG_2_SIZE, MAC_SIZE, NOISE_MESSAGE_HEADER_SIZE, NOISE_MESSAGE_MAX_SIZE,
-        NOISE_PLAINTEXT_MAX_SIZE,
+        NoiseEncryptedHeader, NoiseEncryptedMessage, KK_MSG_1_SIZE, KK_MSG_2_SIZE, MAC_SIZE,
+        NOISE_MESSAGE_HEADER_SIZE, NOISE_MESSAGE_MAX_SIZE, NOISE_PLAINTEXT_MAX_SIZE,
     };
-    use std::{convert::TryInto, str::FromStr};
-
-    pub fn generate_keypair() -> (NoisePrivKey, NoisePubKey) {
-        let mut noise_privkey = NoisePrivKey([0u8; KEY_SIZE]);
-
-        sodiumoxide::init().expect("Initing libsodium");
-        noise_privkey
-            .0
-            .copy_from_slice(&sodiumoxide::randombytes::randombytes(32));
-
-        let noise_pubkey = noise_privkey.pubkey();
-        (noise_privkey, noise_pubkey)
-    }
+    use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::gen_keypair;
+    use std::convert::TryInto;
 
     #[test]
     fn test_bidirectional_roundtrip() {
-        let (initiator_privkey, initiator_pubkey) = generate_keypair();
-        let (responder_privkey, responder_pubkey) = generate_keypair();
+        let (initiator_pubkey, initiator_privkey) = gen_keypair();
+        let (responder_pubkey, responder_privkey) = gen_keypair();
 
         // client
         let (cli_act_1, msg_1) =
@@ -350,8 +315,8 @@ pub mod tests {
 
     #[test]
     fn test_message_size_limit() {
-        let (initiator_privkey, initiator_pubkey) = generate_keypair();
-        let (responder_privkey, responder_pubkey) = generate_keypair();
+        let (initiator_pubkey, initiator_privkey) = gen_keypair();
+        let (responder_pubkey, responder_privkey) = gen_keypair();
 
         // client
         let (_, msg_1) =
@@ -389,8 +354,8 @@ pub mod tests {
 
     #[test]
     fn test_bad_messages() {
-        let (initiator_privkey, initiator_pubkey) = generate_keypair();
-        let (responder_privkey, responder_pubkey) = generate_keypair();
+        let (initiator_pubkey, initiator_privkey) = gen_keypair();
+        let (responder_pubkey, responder_privkey) = gen_keypair();
 
         // KK handshake fails if messages are badly formed.
         // Without a valid cli_act_2 nor serv_act_2, no KKChannel can be constructed.
@@ -403,11 +368,5 @@ pub mod tests {
 
         let bad_msg = KKMessageActTwo([1u8; KK_MSG_2_SIZE]);
         KKHandshakeActTwo::initiator(cli_act_1, &bad_msg).expect_err("So is this one.");
-    }
-
-    #[test]
-    fn test_pubkey_from_str() {
-        NoisePubKey::from_str("61feafb2db96bf650b496c74c24ce92fa608e271b4092405f3364c9f8466df66")
-            .expect("Parsing an invalid but well-encoded pubkey");
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -8,7 +8,7 @@ use crate::{
     error::Error,
     noise::{
         KKChannel, KKHandshakeActOne, KKHandshakeActTwo, KKMessageActOne, KKMessageActTwo,
-        NoiseEncryptedHeader, NoiseEncryptedMessage, NoisePrivKey, NoisePubKey, KK_MSG_1_SIZE,
+        NoiseEncryptedHeader, NoiseEncryptedMessage, PublicKey, SecretKey, KK_MSG_1_SIZE,
         KK_MSG_2_SIZE, NOISE_MESSAGE_HEADER_SIZE,
     },
 };
@@ -28,8 +28,8 @@ impl KKTransport {
     /// Connect to server at given address, and enact Noise handshake with given private key.
     pub fn connect(
         addr: SocketAddr,
-        my_noise_privkey: &NoisePrivKey,
-        their_noise_pubkey: &NoisePubKey,
+        my_noise_privkey: &SecretKey,
+        their_noise_pubkey: &PublicKey,
     ) -> Result<KKTransport, Error> {
         let mut stream = TcpStream::connect_timeout(&addr, Duration::from_secs(10))?;
 
@@ -54,8 +54,8 @@ impl KKTransport {
     /// This is used by servers to identify the origin of the message.
     pub fn accept(
         listener: &TcpListener,
-        my_noise_privkey: &NoisePrivKey,
-        their_possible_pubkeys: &[NoisePubKey],
+        my_noise_privkey: &SecretKey,
+        their_possible_pubkeys: &[PublicKey],
     ) -> Result<KKTransport, Error> {
         let (mut stream, _) = listener.accept().map_err(|e| Error::Transport(e))?;
 
@@ -143,7 +143,7 @@ impl KKTransport {
     }
 
     /// Get the static public key of the peer
-    pub fn remote_static(&self) -> NoisePubKey {
+    pub fn remote_static(&self) -> PublicKey {
         self.channel.remote_static()
     }
 }
@@ -151,33 +151,20 @@ impl KKTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snow::{resolvers::SodiumResolver, Builder, Keypair};
-    use std::convert::TryInto;
+    use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::gen_keypair;
     use std::thread;
-
-    /// Revault must specify the SodiumResolver to use sodiumoxide as the cryptography provider
-    /// when generating a static key pair for secure communication.
-    pub fn generate_keypair() -> Keypair {
-        let noise_params = "Noise_KK_25519_ChaChaPoly_SHA256".parse().unwrap();
-        Builder::with_resolver(noise_params, Box::new(SodiumResolver::default()))
-            .generate_keypair()
-            .unwrap()
-    }
 
     #[test]
     fn test_transport_kk() {
-        let (client_keypair, server_keypair) = (generate_keypair(), generate_keypair());
-
-        let client_pubkey = NoisePubKey(client_keypair.public[..].try_into().unwrap());
-        let server_pubkey = NoisePubKey(server_keypair.public[..].try_into().unwrap());
-        let server_privkey = NoisePrivKey(server_keypair.private[..].try_into().unwrap());
+        let ((client_pubkey, client_privkey), (server_pubkey, server_privkey)) =
+            (gen_keypair(), gen_keypair());
 
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
 
         // client thread
         let cli_thread = thread::spawn(move || {
-            let my_noise_privkey = NoisePrivKey(client_keypair.private[..].try_into().unwrap());
+            let my_noise_privkey = client_privkey;
             let their_noise_pubkey = server_pubkey;
 
             let mut cli_channel =


### PR DESCRIPTION
There's no need to re-implement PublicKey and SecretKey structs within revault_net. Instead use PublicKey and SecretKey from sodiumoxide which already have conversion functions and memory zeroing for SecretKey when it is dropped.

Fixes #29

based on #33